### PR TITLE
fix(GraspPrecompute) GraspPrecompute node uses asyncspinner to update…

### DIFF
--- a/src/grasp_precompute_action.cpp
+++ b/src/grasp_precompute_action.cpp
@@ -10,11 +10,14 @@ int main(int argc, char** argv)
     ROS_INFO("Starting grasp precompute node");
 
     ros::init(argc, argv, "grasp_precompute_server");
+    
+    ros::AsyncSpinner spinner(4); // Use 4 threads
+    spinner.start();
 
     GraspPrecompute gp;
     if (gp.initialize())
     {
-      ros::spin();
+      ros::waitForShutdown();
     }
     else
     {


### PR DESCRIPTION
… the joint states while waiting for current state. Using ros::spin only after initialization causes the getCurrentState function to fail