### PR TITLE
Fix dependency on orocos_kdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
     geolib2 # Temp
     message_generation
     moveit_ros_planning_interface
+    orocos_kdl
     sensor_msgs
     std_msgs
 )

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>moveit_ros_planning_interface</build_depend>
+  <build_depend>orocos_kdl</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
@@ -37,6 +38,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>moveit_msgs</run_depend>
   <run_depend>moveit_ros_planning_interface</run_depend>
+  <run_depend>orocos_kdl</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
This package makes use of headers from `kdl/*` so it must depend on the
package that provides those headers, namely `orocos_kdl`.

Without this PR, the package will use the system installed `orocos_kdl`, which is a different version. The build then gives the following error:
```
/home/user/ros/tue/src/tue_manipulation/src/constrained_chainiksolvervel_pinv.cpp: In member function ‘virtual void KDL::ConstrainedChainIkSolverVel_pinv::updateInternalDataStructures()’:
/home/user/ros/tue/src/tue_manipulation/src/constrained_chainiksolvervel_pinv.cpp:48:17: error: ‘class KDL::ChainJntToJacSolver’ has no member named ‘updateInternalDataStructures’
         jnt2jac.updateInternalDataStructures();
                 ^
make[2]: *** [CMakeFiles/constrained_ik_solver.dir/src/constrained_chainiksolvervel_pinv.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/user/ros/tue/src/tue_manipulation/src/constrained_chainiksolverpos_nr_jl.cpp: In member function ‘virtual void KDL::ConstrainedChainIkSolverPos_NR_JL::updateInternalDataStructures()’:
/home/user/ros/tue/src/tue_manipulation/src/constrained_chainiksolverpos_nr_jl.cpp:49:18: error: ‘class KDL::ChainIkSolverVel’ has no member named ‘updateInternalDataStructures’
         iksolver.updateInternalDataStructures();
                  ^
/home/user/ros/tue/src/tue_manipulation/src/constrained_chainiksolverpos_nr_jl.cpp:50:18: error: ‘class KDL::ChainFkSolverPos’ has no member named ‘updateInternalDataStructures’
         fksolver.updateInternalDataStructures();
                  ^
make[2]: *** [CMakeFiles/constrained_ik_solver.dir/src/constrained_chainiksolverpos_nr_jl.cpp.o] Error 1
make[1]: *** [CMakeFiles/constrained_ik_solver.dir/all] Error 2
make: *** [all] Error 2
```